### PR TITLE
Adjust block size to 69 coins per block

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1136,7 +1136,9 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
     if (halvings >= 64)
         return 0;
 
-    CAmount nSubsidy = 50 * COIN;
+	// Adjust block size to 69 coins per block
+    CAmount nSubsidy = 69 * COIN;
+
     // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
     nSubsidy >>= halvings;
     return nSubsidy;


### PR DESCRIPTION
Adjust block size to 69 coins per block